### PR TITLE
Comparing malaria data in 705 and 105 reports

### DIFF
--- a/analysis/malaria_comp105-705.r
+++ b/analysis/malaria_comp105-705.r
@@ -1,0 +1,146 @@
+#### This program looks at the data relevant to Malaria analysis, and compares data from reports 705s and report 105
+#### To ensure that the data from these two sources is consistant
+
+## Author : Grégoire Lurton
+## Date   : July 2014
+
+
+library(sqlshare)
+library(plyr)
+library(ggplot2)
+library(zoo)
+library(maptools)
+library(stringr)
+library(reshape2)
+library(lme4)
+
+setwd("J:/Project/abce/ken/HMIS")
+
+
+zones <- readShapePoly("data/pfprInZones.shp")
+MalariaDataPed <- fetch.data.frame('select District , Value , Year , Month , Indicator
+                                 FROM [grlurton@washington.edu].[705ADataClean]
+                                 WHERE Indicator=\'confirmed malaria\' OR Indicator=\'clinical malaria\' OR Indicator = \'typhoid fever\'OR Indicator =  \'Pneumonia\' AND isnumeric(Value) = 1;')
+MalariaDataAdult <- fetch.data.frame('select District , Value , Year , Month , Indicator
+                                 FROM [grlurton@washington.edu].[705BDataClean]
+                                 WHERE Indicator=\'confirmed malaria\' OR Indicator=\'clinical malaria\' OR Indicator = \'typhoid fever\'OR Indicator =  \'Pneumonia\' AND isnumeric(Value) = 1;')
+
+Malaria105 <- fetch.data.frame('select District , Value , Year , Month , Level , Indicator
+                                 FROM [grlurton@washington.edu].[105DataClean]
+                                 WHERE Indicator=\'total number of inpatient malaria cases\' 
+                                        OR Indicator=\'number of under five years treated for malaria\' 
+                                        OR Indicator = \'number of patients over five years treated for malaria\'
+                                        OR Indicator =  \'number of malaria inpatient deaths\' 
+                                        OR Indicator =  \'number of llitn distributed to pregnant women\' 
+                                        OR Indicator= \'number of llitns distributed to children under 5 years\' 
+                                        OR Indicator=\'number of children over five years treated for malaria\' 
+                                        OR Indicator= \'number of < 1 deaths occuring at facility\'
+                                        AND isnumeric(Value) = 1;')
+
+
+MalariaDataAdult$Cohort <- "> 5 years"
+MalariaDataPed$Cohort <- "< 5 years"
+
+MalariaData <- rbind(MalariaDataAdult , MalariaDataPed)
+MalariaData$CalMonth <- as.Date(as.yearmon(paste(MalariaData$Month , MalariaData$Year  , sep = '-') , "%B-%Y"))
+MalariaData <- subset(MalariaData, !is.na(Value) & !is.na(CalMonth) & District %in% zones@data$District)
+
+Malaria105$CalMonth <- as.Date(as.yearmon(paste(Malaria105$Month , Malaria105$Year  , sep = '-') , "%B-%Y"))
+Malaria105 <- subset(Malaria105 , !is.na(Value) & !is.na(CalMonth) & District %in% zones@data$District)
+
+Malaria105$Cohort[Malaria105$Indicator == "number of under five years treated for malaria"] <- "< 5 years"
+Malaria105$Cohort[Malaria105$Indicator == "number of patients over five years treated for malaria"] <- "> 5 years"
+
+Malaria105$Indicator <- as.character(Malaria105$Indicator)
+Malaria105$Indicator[Malaria105$Indicator == "number of under five years treated for malaria"] <-
+  Malaria105$Indicator[Malaria105$Indicator == "number of patients over five years treated for malaria"] <-
+  "treated malaria"
+
+MalariaCases105 <- subset(Malaria105 , Indicator == "treated malaria")
+MalariaCases705 <- subset(MalariaData , Indicator == "confirmed malaria")
+####Summing Malaria cases accross each data set
+
+Summed705 <- ddply(MalariaCases705 , .(District , CalMonth , Indicator) , 
+                   function(x){
+                     data.frame(totalCases = sum(x$Value , na.rm = TRUE))
+                   },
+                   .progress = 'text')
+
+
+Summed105 <- ddply(MalariaCases105 , .(District , CalMonth , Indicator) , 
+                   function(x){
+                     data.frame(totalCases = sum(x$Value , na.rm = TRUE))
+                   }, .progress = 'text')
+
+trimmed705 <- ddply(Summed705 , .(District) , 
+                         function(x){
+                           subset(x , !(totalCases %in% boxplot.stats(totalCases)$out))
+                         })
+
+trimmed105 <- ddply(Summed105 , .(District) , 
+                         function(x){
+                           subset(x , !(totalCases %in% boxplot.stats(totalCases)$out))
+                         })
+
+
+corMatrix <- merge(trimmed105[,-3] , trimmed705[,-3] , by = c("District", 'CalMonth') , all = FALSE)
+
+
+corrMal705vs105 <- ddply(corMatrix , .(District) , 
+                         function(x){
+                           data.frame(corr = cor(x$totalCases.x , x$totalCases.y))
+                         }
+                         )
+
+corrMal705vs105 <- subset(corrMal705vs105 , !is.na(corr))
+
+nValues <- ddply(Summed105 , .(District) , 
+                 function(x){
+                   data.frame(Nobs = nrow(x))
+                 }
+                 )
+
+
+corrMal705vs105 <- merge(corrMal705vs105 , nValues)
+
+corrMal705vs105$District <- factor(as.character(corrMal705vs105$District) , 
+                                   levels = as.character(corrMal705vs105$District)[order(corrMal705vs105$corr)])
+
+qplot(data = corrMal705vs105 , x = District , y = corr , geom = 'bar' , stat = 'identity' , fill = Nobs) +
+  coord_flip() + theme_bw() + ylab('Correlation between Clinical Malaria in 705 and Treated Malaria in 105') +
+  scale_fill_gradient(low="grey" , high = "dark red")
+
+goodCorrDist <- as.character(corrMal705vs105$District[corrMal705vs105$corr >= 0.7])
+medCorrDist <- as.character(corrMal705vs105$District[corrMal705vs105$corr < 0.7 & corrMal705vs105$corr >= 0.5])
+badCorrDist <- as.character(corrMal705vs105$District[corrMal705vs105$corr < 0.5 & corrMal705vs105$corr >= 0])
+negCorrDist <- as.character(corrMal705vs105$District[corrMal705vs105$corr < 0])
+
+
+
+
+
+
+####Looking at it
+
+NValDist <- ddply(Summed105 , .(District) , function(x) nrow(x[x$Value != 0 ,]))
+SufficientDataDist <- subset(NValDist , V1 > 21)
+
+Summed105 <- subset(Summed105 , District %in% SufficientDataDist$District)
+Summed105$District <- as.character(Summed105$District)
+
+qplot(data = Summed105[Summed105$Indicator != "treated malaria" ,] , x = CalMonth , y = Value , col = Indicator , geom = 'line') +
+  facet_wrap(~District , scales = "free")
+ComparePlot <- rbind(data.frame(subset(Summed105 ,
+                                       Indicator == "treated malaria"), 
+                                Source = "105 Report") ,
+                     data.frame(subset(MalariaData , 
+                                       Indicator %in% c('clinical malaria' , 'confirmed malaria') ,
+                                       select = c(Indicator , CalMonth , District , Value , Cohort)
+                     ) , Source = "705 Reports")
+)
+
+ComparePlot <- subset(ComparePlot , !is.na(CalMonth) & !is.na(Value))
+
+ggplot(data = ComparePlot , aes(x = CalMonth , y = Value , colour = Indicator , linetype = Cohort) )+ 
+  geom_line() +
+  facet_wrap(~District , scales = "free_y") + theme_bw()

--- a/analysis/malaria_diag.r
+++ b/analysis/malaria_diag.r
@@ -34,23 +34,9 @@ Malaria105 <- fetch.data.frame('select District , Value , Year , Month , Level ,
 MalariaDataAdult$Cohort <- "> 5 years"
 MalariaDataPed$Cohort <- "< 5 years"
 
-
-
-
 MalariaData <- rbind(MalariaDataAdult , MalariaDataPed)
 MalariaData$CalMonth <- as.Date(as.yearmon(paste(MalariaData$Month , MalariaData$Year  , sep = '-') , "%B-%Y"))
 Malaria105$CalMonth <- as.Date(as.yearmon(paste(Malaria105$Month , Malaria105$Year  , sep = '-') , "%B-%Y"))
-
-
-####A enlever
-##################################################################
-formatNames <- function(x){
-  library(stringr)
-  tolower(str_trim(as.character(x)))
-}
-
-MalariaData$District <- formatNames(MalariaData$District)
-##################################################################
 
 
 ratio_clinic_confirm <- ddply(MalariaData , .( CalMonth , District , Cohort) ,

--- a/analysis/malaria_diag.r
+++ b/analysis/malaria_diag.r
@@ -5,20 +5,21 @@ library(zoo)
 library(maptools)
 library(stringr)
 library(reshape2)
+library(lme4)
 
 setwd("J:/Project/abce/ken/HMIS")
 
 
 zones <- readShapePoly("data/pfprInZones.shp")
 MalariaDataPed <- fetch.data.frame('select District , Value , Year , Month , Indicator
-                                 FROM [grlurton@washington.edu].[705ADataComplete]
+                                 FROM [grlurton@washington.edu].[705ADataClean]
                                  WHERE Indicator=\'confirmed malaria\' OR Indicator=\'clinical malaria\' OR Indicator = \'typhoid fever\'OR Indicator =  \'Pneumonia\' AND isnumeric(Value) = 1;')
 MalariaDataAdult <- fetch.data.frame('select District , Value , Year , Month , Indicator
-                                 FROM [grlurton@washington.edu].[705BDataComplete]
+                                 FROM [grlurton@washington.edu].[705BDataClean]
                                  WHERE Indicator=\'confirmed malaria\' OR Indicator=\'clinical malaria\' OR Indicator = \'typhoid fever\'OR Indicator =  \'Pneumonia\' AND isnumeric(Value) = 1;')
 
 Malaria105 <- fetch.data.frame('select District , Value , Year , Month , Level , Indicator
-                                 FROM [grlurton@washington.edu].[105DataComplete]
+                                 FROM [grlurton@washington.edu].[105DataClean]
                                  WHERE Indicator=\'total number of inpatient malaria cases\' 
                                         OR Indicator=\'number of under five years treated for malaria\' 
                                         OR Indicator = \'number of patients over five years treated for malaria\'
@@ -30,37 +31,57 @@ Malaria105 <- fetch.data.frame('select District , Value , Year , Month , Level ,
                                         AND isnumeric(Value) = 1;')
 
 
-MalariaDataAdultPrep <- MalariaDataAdult
+MalariaDataAdult$Cohort <- "> 5 years"
+MalariaDataPed$Cohort <- "< 5 years"
 
-MalariaDataPedPrep <- PrepareData(MalariaDataPed)
-Malaria105Prep <- PrepareData(Malaria105)
 
-MalariaDataAdultPrep$Cohort <- "> 5 years"
-MalariaDataPedPrep$Cohort <- "< 5 years"
 
-MalariaData <- rbind(MalariaDataAdultPrep , MalariaDataPedPrep)
+
+MalariaData <- rbind(MalariaDataAdult , MalariaDataPed)
+MalariaData$CalMonth <- as.Date(as.yearmon(paste(MalariaData$Month , MalariaData$Year  , sep = '-') , "%B-%Y"))
+Malaria105$CalMonth <- as.Date(as.yearmon(paste(Malaria105$Month , Malaria105$Year  , sep = '-') , "%B-%Y"))
+
+
+####A enlever
+##################################################################
+formatNames <- function(x){
+  library(stringr)
+  tolower(str_trim(as.character(x)))
+}
+
+MalariaData$District <- formatNames(MalariaData$District)
+##################################################################
+
 
 ratio_clinic_confirm <- ddply(MalariaData , .( CalMonth , District , Cohort) ,
                               function(x){
                                 print(x$District)
-                                if (length(x$Value[x$Indicator == "confirmed malaria"]) > 0 &
+                                if (length(x$Value[x$Indicator %in% c("confirmed malaria")]) > 0 &
                                   length(x$Value[x$Indicator == "clinical malaria"]) > 0 ){
-                                    ratio <- x$Value[x$Indicator == "confirmed malaria"][1] / x$Value[x$Indicator == "clinical malaria"][1] 
+                                    ratio <- x$Value[x$Indicator %in% c("confirmed malaria")][1] / x$Value[x$Indicator == "clinical malaria"][1] 
                                     data.frame(ratio , 
                                                clinic = x$Value[x$Indicator == "clinical malaria"][1])
                                   }
                                 })
 
+ratio_clinic_confirm <- subset(ratio_clinic_confirm , ratio <= 1 & clinic < 55000)
+meanRatio <- ddply(ratio_clinic_confirm , .(District) , function(x) mean(x$ratio))
+colnames(meanRatio)[2] <- "mean"
+meanRatio$District <- ordered(meanRatio$District , levels = meanRatio$District[order(meanRatio$mean)])
 
-ratio_clinic_confirm <- subset(ratio_clinic_confirm , ratio <= 1)
+
+ratio_clinic_confirm <- merge(meanRatio , ratio_clinic_confirm)
+
 qplot(data = ratio_clinic_confirm , x = clinic , y = ratio , col = Cohort)+
-  facet_wrap(~District) + theme_bw()
-
+  facet_wrap(~District) + theme_bw() +
+  geom_hline(aes(yintercept = mean))
+  
 qplot(data = ratio_clinic_confirm , x = CalMonth , y = ratio , col = Cohort)+
-  facet_wrap(~District) + theme_bw()
+  facet_wrap(~District) + theme_bw()+
+  geom_hline(aes(yintercept = mean))
 
-Summed105 <- ddply(Malaria105Prep , .(District , CalMonth , Indicator) , 
-                         function(x) sum(x$Value) , .progress = 'text')
+Summed105 <- ddply(Malaria105 , .(District , CalMonth , Indicator) , 
+                         function(x) sum(x$Value , na.rm = T) , .progress = 'text')
 colnames(Summed105)[4] <- 'Value'
 
 
@@ -81,7 +102,9 @@ ComparePlot <- rbind(data.frame(subset(Summed105 ,
                             ) , Source = "705 Reports")
                      )
 
-ggplot(data = ComparePlot[ComparePlot$District == "laikipia west" ,] , aes(x = CalMonth , y = Value , colour = Indicator , linetype = Cohort) )+ 
+ComparePlot <- subset(ComparePlot , !is.na(CalMonth) & !is.na(Value))
+
+ggplot(data = ComparePlot , aes(x = CalMonth , y = Value , colour = Indicator , linetype = Cohort) )+ 
   geom_line() +
   facet_wrap(~District , scales = "free_y") + theme_bw()
   
@@ -94,18 +117,13 @@ plot(ratio_clinic_confirm$ratio  , fitted(fit))
 lines(x = c(0,1) , y = c(0,1) , col = 'red')
 
 
-
-
-
-
-
 LargeMalariaValue <- dcast(MalariaData , CalMonth + District ~ Indicator , value.var = "Value" ,fun.aggregate = function(x) max(x , na.rm = TRUE))
 colnames(LargeMalariaValue) <- c("CalMonth","District","clinMal","ConfMal","pneumonia","typhoid")
 
 forFit <- subset(LargeMalariaRate , !is.na(pneumonia) & !is.na(clinMal) 
                  & is.finite(clinMal) & !is.nan(clinMal))
 
-library(lme4)
+
 fit <- lm(pneumonia ~ clinMal:District, data = forFit)
 
 LargeMalariaRate <- dcast(MalariaData , CalMonth + District ~ Indicator , value.var = "Rate" ,fun.aggregate = function(x) max(x , na.rm = TRUE))

--- a/analysis/pfpr_analysis.r
+++ b/analysis/pfpr_analysis.r
@@ -53,7 +53,7 @@ ggplot(data = TotalCases ,
   geom_point() +
   geom_point(aes(x = ghapfprpop , y = TotConf) , col = "red" )+
   theme_bw() +
-  xlab('Pfpr') + ylab('Incidence rate clinical malaria')
+  ylab('Number of cases in hospital reports (red  = confirmed)') + xlab('Number of people with Pfp')
 
 ##Deleting outliers
 
@@ -64,7 +64,7 @@ ggplot(data = TotalCases ,
   geom_point() +
   geom_point(aes(x = ghapfprpop , y = TotConf) , col = "red" )+
   theme_bw() +
-  xlab('Pfpr') + ylab('Incidence rate clinical malaria')
+  ylab('Number of cases in hospital reports (red  = confirmed)') + xlab('Number of people with Pfp')
 
 ##0 Values are considered missing data...
 

--- a/analysis/pfpr_analysis.r
+++ b/analysis/pfpr_analysis.r
@@ -1,58 +1,79 @@
+library(maptools)
+library(sqlshare)
+library(zoo)
+library(plyr)
+library(ggplot2)
 
+setwd("J:/Project/abce/ken/HMIS")
 
-
+pfprZones <- readShapePoly("data/pfprInZones.shp")
 
 pal <- colorRampPalette(c('white' , 'lightblue', 'darkred'))
 
 par(mfrow = c(1,2))
-plot(MapPfpr , col = pal(50)[as.numeric(cut(MapPfpr$pfpr,breaks = 50))])
+plot(pfprZones , col = pal(50)[as.numeric(cut(pfprZones$pfpr,breaks = 50))])
 title(main = 'Distribution of pfpr')
-plot(MapPfpr , col = pal(50)[cut(MapPfpr$ghapfprpop,breaks = 50)])
+plot(pfprZones , col = pal(50)[cut(pfprZones$ghapfprpop,breaks = 50)])
 title(main = 'Nbr Malaria infected people')
 par(mfrow = c(1,1))
 
-
-MalariaCases <- fetch.data.frame('select District , Value , Year , Month 
+MalariaCases <- fetch.data.frame('select District , Value , Year , Month , Indicator
                                  FROM [grlurton@washington.edu].[705BDataComplete]
-                                 WHERE Indicator=\'confirmed malaria\' AND isnumeric(Value) = 1;')
+                                 WHERE Indicator=\'confirmed malaria \' OR Indicator = \'clinical malaria\' AND isnumeric(Value) = 1;')
 
-#MalariaCases <- CleanMonths(MalariaCases)
 MalariaCases$Month <- as.yearmon(paste(MalariaCases$Month , MalariaCases$Year  , sep = '-') , "%B-%Y")
 
-MalariaStat <- ddply(MalariaCases , .(District) , function(x){data.frame(mean  = mean(x$Value) , median = median(x$Value))})
-CountCases <- ddply(MalariaCases , .(District , Month) , function(x){data.frame(sum  = sum(x$Value , na.rm = TRUE))})
+MalariaStat <- ddply(MalariaCases , .(District) , function(x){
+  data.frame(meanConf  = mean(x$Value[x$Indicator == 'confirmed malaria ']  , na.rm = T) , 
+             medianConf = median(x$Value[x$Indicator == 'confirmed malaria '], na.rm = T) ,
+             meanClin  = mean(x$Value[x$Indicator == 'clinical malaria'], na.rm = T) , 
+             medianClin = median(x$Value[x$Indicator == 'clinical malaria'], na.rm = T))})
+CountCases <- ddply(MalariaCases , .(District , Month) , function(x){
+  data.frame(sumConf  = sum(x$Value[x$Indicator == 'confirmed malaria '] , na.rm = TRUE),
+             sumClin = sum(x$Value[x$Indicator == 'clinical malaria'] , na.rm = TRUE))})
+
+####A enlever
+##################################################################
+formatNames <- function(x){
+  library(stringr)
+  tolower(str_trim(as.character(x)))
+}
 
 MalariaStat$District <- formatNames(MalariaStat$District)
 CountCases$District <- formatNames(CountCases$District)
+##################################################################
 
-DataPlot <- merge(MalariaStat, pfpr , all.y = FALSE , by.x = 'District' , by.y = 'District')
-SumDataPlot <- merge(CountCases, pfpr , all.y = FALSE , by.x = 'District' , by.y = 'District')
 
-pdf("pfprdef.pdf", width=14.85, height=10.5)
+DataPlot    <- merge(MalariaStat, pfprZones@data , all.y = FALSE , by.x = 'District' , by.y = 'District')
+SumDataPlot <- merge(CountCases, pfprZones@data , all.y = FALSE , by.x = 'District' , by.y = 'District')
+
+
+par(mfrow = c(2,2))
+plot(order(DataPlot$ghapfprpop) , order(DataPlot$meanClin) ,
+     xlab = 'Number people with pfp (Rank)' , 
+     ylab = 'Mean number clinical malaria (Rank)')
+plot(order(DataPlot$pfpr) , order(DataPlot$meanClin / DataPlot$population),
+     xlab = 'Pfpr (Rank)' , 
+     ylab = 'Mean rate clinical malaria (Rank)')
+plot(order(DataPlot$ghapfprpop) , order(DataPlot$meanConf),
+     xlab = 'Number people with pfp (Rank)' , 
+     ylab = 'Mean number confirmed malaria (Rank)')
+plot(order(DataPlot$pfpr) , order(DataPlot$meanConf / DataPlot$population),
+     xlab = 'Pfpr (Rank)' , 
+     ylab = 'Mean rate confirmed malaria (Rank)')
+
 ggplot(data = DataPlot ,
-       aes(x = pfpr , y = 1000 * 12 * mean /(population)  , 
+       aes(x = pfpr , y = 1000 * 12 * meanClin /(population)  , 
            #size= population  ,
            col = pfpr , label = District)) + 
   geom_text() +
   theme_bw() + scale_colour_gradient(low="blue" , high = "red") +
-  xlab('Pfpr') + ylab('Incidence rate') 
-
-ggplot(data = SumDataPlot ,
-       aes(x = pfpr , y = 1000 * 12 * sum /(population)   , label = District)) + 
-  # geom_text() +
-  geom_point() + geom_smooth(method="rlm") +
-  theme_bw() + #scale_colour_gradient(low="blue" , high = "red") +
-  xlab('Pfpr') + ylab('Incidence rate') 
+  xlab('Pfpr') + ylab('Incidence rate clinical malaria') 
 
 ggplot(data = DataPlot ,
-       aes(x = ghapfprpop , y = mean  , size= population  ,col = pfpr , label = District)) + 
+       aes(x = pfpr , y = 1000 * 12 * meanConf /(population)  , 
+           #size= population  ,
+           col = pfpr , label = District)) + 
   geom_text() +
-  theme_bw() + scale_colour_gradient(low="blue" , high = "red")
-
-
-qplot(data = DataPlot ,
-      x = ghapfprpop , y = median ,  
-      size = 2) +
-  xlab('pfpr * Population') + ylab('Median of confirmed Malaria Cases') +
-  theme_bw() + scale_colour_brewer(palette="Set1")
-dev.off()
+  theme_bw() + scale_colour_gradient(low="blue" , high = "red") +
+  xlab('Pfpr') + ylab('Incidence rate confirmed malaria') 

--- a/extraction/map_indic_705.r
+++ b/extraction/map_indic_705.r
@@ -25,7 +25,7 @@ length(unique(indicatorsB$Indicator))
 indicatorsB$new <- str_trim(indicatorsB$Indicator)
 indicatorsB$new <- str_replace_all(indicatorsB$Indicator, "  ", " ")
 indicatorsB$new  <- tolower(indicatorsB$Indicator)
-indicatorsB$new[indicatorsB$Indicator == "Confirmed Malaria "] <- "confirmed Malaria"
+indicatorsB$new[indicatorsB$Indicator == "Confirmed Malaria "] <- "confirmed malaria"
 length(unique(indicatorsB$new))
 
 sort(unique(indicatorsA$new))

--- a/extraction/metadata_merge.r
+++ b/extraction/metadata_merge.r
@@ -66,15 +66,15 @@ data105$Year[data105$Month %in%
   data105$Year[data105$Month %in% 
                  c("july" , "august" , "september" , "october" , "november" , "december")] - 1
 
-data705A <- subset(merge(data705A, WindowsMeta , by = "Path") , 
-                  select = c(Path , Indicator , District , Month , yearCorrect , Value ))
+data705A <- PrepareData(subset(merge(data705A, WindowsMeta , by = "Path") , 
+                  select = c(Path , Indicator , District , Month , yearCorrect , Value )))
 colnames(data705A)[5] <- "Year"
-data705B <- subset(merge(data705B, WindowsMeta , by = "Path") , 
-                   select = c(Path , Indicator , District , Month , yearCorrect , Value ))
+data705B <- PrepareData(subset(merge(data705B, WindowsMeta , by = "Path") , 
+                   select = c(Path , Indicator , District , Month , yearCorrect , Value )))
 colnames(data705B)[5] <- "Year"
-data710 <- subset(merge(data710, WindowsMeta , by = "Path") , 
+data710 <- PrepareData(subset(merge(data710, WindowsMeta , by = "Path") , 
                    select = c(Path , Sheet , Indicator1 , Indicator2 , 
-                              District , Month , yearCorrect , Value ))
+                              District , Month , yearCorrect , Value )))
 colnames(data710)[7] <- "Year"
 
 write.table(data105  , '105Data.csv' , sep = "\t" , row.names = FALSE)

--- a/extraction/metadata_merge.r
+++ b/extraction/metadata_merge.r
@@ -65,19 +65,33 @@ data105$Year[data105$Month %in%
                c("july" , "august" , "september" , "october" , "november" , "december")] <-
   data105$Year[data105$Month %in% 
                  c("july" , "august" , "september" , "october" , "november" , "december")] - 1
+print("105 clean")
 
 data705A <- PrepareData(subset(merge(data705A, WindowsMeta , by = "Path") , 
                   select = c(Path , Indicator , District , Month , yearCorrect , Value )))
 colnames(data705A)[5] <- "Year"
+print('705A clean')
+
+
 data705B <- PrepareData(subset(merge(data705B, WindowsMeta , by = "Path") , 
                    select = c(Path , Indicator , District , Month , yearCorrect , Value )))
 colnames(data705B)[5] <- "Year"
+print('705B clean')
+
 data710 <- PrepareData(subset(merge(data710, WindowsMeta , by = "Path") , 
                    select = c(Path , Sheet , Indicator1 , Indicator2 , 
                               District , Month , yearCorrect , Value )))
 colnames(data710)[7] <- "Year"
+print('710 clean')
 
-write.table(data105  , '105Data.csv' , sep = "\t" , row.names = FALSE)
-write.table(data705A  , '705AData.csv' , sep = "\t" , row.names = FALSE)
-write.csv(data705B  , '705BData.csv' , sep = "\t" , row.names = FALSE)
-write.csv(data710  , '710Data.csv' , sep = "\t" , row.names = FALSE)
+print('Saving Clean files')
+print('Saving 105')
+write.table(data105  , '105Data.csv' , sep = "\t" , row.names = FALSE , quote = FALSE)
+print('Saving 705A')
+write.table(data705A  , '705AData.csv' , sep = "\t" , row.names = FALSE , quote = FALSE)
+print('Saving 705B')
+write.table(data705B  , '705BData.csv' , sep = "\t" , row.names = FALSE , quote = FALSE)
+print('Saving 710')
+write.table(data710  , '710Data.csv' , sep = "\t" , row.names = FALSE , quote = FALSE)
+
+q()

--- a/extraction/metadata_merge.r
+++ b/extraction/metadata_merge.r
@@ -2,7 +2,7 @@
 #### output are the total datasets with all data and metadata with corresponding datasets
 #### It also cleans and standardizes month names and district names
 
-#### This part was originally made in sqlshare but ended up with problems in the 105. 
+#### This part was originally made in sqlshare but ended up with problems in the 105 because of reporting period 
 #### If solution found, may be moved back
 
 ## Author : Grégoire Lurton


### PR DESCRIPTION
I make a separate thread for specific issue regarding the coherence of data between different types of report.

It is relevant right now regarding the malaria confirmation rates work, because malaria diagnoses and malaria treatment are in separate reports.

For now code is pretty rough; the idea being to see correlation between number of cilnical malaria diagnoses (from 705s) and number of treatment for malaria given (from 105), all ages pooled. below are these correlation. I think it is not so bad considering the two series are not exactly the same quantity. I'm trying to find a legible way to look at the series themselve to see what is really happening.

![image](https://cloud.githubusercontent.com/assets/7142711/3706708/293b5d0e-142c-11e4-8185-ad0d4e0696eb.png)
